### PR TITLE
Ruby interfaces

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,4 @@ group :development do
   gem "steep"
   gem "interface"
 end
+

--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,3 @@ group :development do
   gem "steep"
   gem "interface"
 end
-

--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,5 @@ group :development do
   gem "yard"
   gem "typeprof"
   gem "steep"
+  gem "interface"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,7 @@ GEM
     fileutils (1.7.3)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    interface (1.0.5)
     json (2.12.2)
     language_server-protocol (3.17.0.5)
     listen (3.9.0)
@@ -81,6 +82,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  interface
   minitest
   steep
   typeprof

--- a/lib/core/controller.rb
+++ b/lib/core/controller.rb
@@ -6,8 +6,6 @@
 # Copyright(c) 2025 Saad Shams <saad.shams@puremvc.org>
 # Your reuse is governed by the BSD 3-Clause License
 
-require_relative '../interfaces/i_controller'
-
 module PureMVC
   # A Multiton <code>IController</code> implementation.
   #
@@ -31,7 +29,7 @@ module PureMVC
   # @see SimpleCommand
   # @see MacroCommand
   class Controller
-    include IController
+    implements IController
 
     # Message Constants
     MULTITON_MSG = "Controller instance for this Multiton key already constructed!"

--- a/lib/core/model.rb
+++ b/lib/core/model.rb
@@ -6,8 +6,6 @@
 # Copyright(c) 2025 Saad Shams <saad.shams@puremvc.org>
 # Your reuse is governed by the BSD 3-Clause License
 
-require_relative '../interfaces/i_model'
-
 module PureMVC
   # A Multiton <code>IModel</code> implementation.
   #
@@ -25,7 +23,7 @@ module PureMVC
   # @see Proxy
   # @see IProxy
   class Model
-    include IModel
+    implements IModel
 
     # Message Constants
     MULTITON_MSG = "Model instance for this Multiton key already constructed!"

--- a/lib/core/view.rb
+++ b/lib/core/view.rb
@@ -6,8 +6,6 @@
 # Copyright(c) 2025 Saad Shams <saad.shams@puremvc.org>
 # Your reuse is governed by the BSD 3-Clause License
 
-require_relative '../interfaces/i_view'
-
 module PureMVC
   # A Multiton <code>IView</code> implementation.
   #
@@ -25,7 +23,7 @@ module PureMVC
   # @see Observer
   # @see Notification
   class View
-    include IView
+    implements IView
 
     MULTITON_MSG = "View instance for this Multiton key already constructed!"
     private_constant :MULTITON_MSG

--- a/lib/interfaces/i_command.rb
+++ b/lib/interfaces/i_command.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'interface'
 
 # i_command.rb
 # PureMVC Ruby Multicore
@@ -10,7 +11,7 @@ module PureMVC
   # The interface definition for a PureMVC Command.
   #
   # @see INotification
-  module ICommand
+  ICommand = interface {
     # Execute the <code>ICommand</code>'s logic to handle a given <code>INotification</code>.
     #
     # @abstract This method must be implemented by the concrete command.
@@ -19,5 +20,5 @@ module PureMVC
     def execute(notification)
       raise NotImplementedError, "#{self.class} must implement #execute"
     end
-  end
+  }
 end

--- a/lib/interfaces/i_controller.rb
+++ b/lib/interfaces/i_controller.rb
@@ -1,3 +1,4 @@
+require 'interface'
 # frozen_string_literal: true
 
 # i_controller.rb
@@ -25,7 +26,7 @@ module PureMVC
   #
   # @see INotification
   # @see ICommand
-  module IController
+  IController = interface {
     # Register a particular <code>ICommand</code> class as the handler
     # for a particular <code>INotification</code>.
     #
@@ -65,5 +66,5 @@ module PureMVC
       raise NotImplementedError, "#{self.class} must implement #remove_command"
     end
 
-  end
+  }
 end

--- a/lib/interfaces/i_facade.rb
+++ b/lib/interfaces/i_facade.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'interface'
 
 # i_facade.rb
 # PureMVC Ruby Multicore
@@ -22,8 +23,8 @@ module PureMVC
   # @see IController
   # @see ICommand
   # @see INotification
-  module IFacade
-    include INotifier
+  IFacade = interface {
+    implements INotifier
 
     # Register an <code>ICommand</code> with the <code>Controller</code>.
     #
@@ -125,5 +126,5 @@ module PureMVC
       raise NotImplementedError, "#{self.class} must implement #notify_observers"
     end
 
-  end
+  }
 end

--- a/lib/interfaces/i_mediator.rb
+++ b/lib/interfaces/i_mediator.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'interface'
 
 # i_mediator.rb
 # PureMVC Ruby Multicore
@@ -35,7 +36,7 @@ module PureMVC
   # and register it as an Observer for each <code>INotification</code> name returned by <code>list_notification_interests</code>.
   #
   # @see INotification
-  module IMediator
+  IMediator = interface {
     # @return [String] The name of the Mediator.
     def name
       raise NotImplementedError, "#{self.class} must implement #name"
@@ -71,5 +72,5 @@ module PureMVC
     def on_remove
       raise NotImplementedError, "#{self.class} must implement #on_remove"
     end
-  end
+  }
 end

--- a/lib/interfaces/i_model.rb
+++ b/lib/interfaces/i_model.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'interface'
 
 # i_model.rb
 # PureMVC Ruby Multicore
@@ -16,7 +17,7 @@ module PureMVC
   #
   # - Maintain a cache of <code>IProxy</code> instances
   # - Provide methods for registering, retrieving, and removing <code>IProxy</code> instances
-  module IModel
+  IModel = interface {
     # Register an <code>IProxy</code> instance with the <code>Model</code>.
     #
     # @param proxy [IProxy] an object reference to be held by the <code>Model</code>.
@@ -48,6 +49,6 @@ module PureMVC
       raise NotImplementedError, "#{self.class} must implement #remove_proxy"
     end
 
-  end
+  }
 
 end

--- a/lib/interfaces/i_notification.rb
+++ b/lib/interfaces/i_notification.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'interface'
 
 # i_notification.rb
 # PureMVC Ruby Multicore
@@ -37,7 +38,7 @@ module PureMVC
   #
   # @see IView
   # @see IObserver
-  module INotification
+  INotification = interface {
     # @return [String] the name of the notification
     def name
       raise NotImplementedError, "#{self.class} must implement #name"
@@ -59,5 +60,5 @@ module PureMVC
     def to_s
       raise NotImplementedError, "#{self.class} must implement #to_s"
     end
-  end
+  }
 end

--- a/lib/interfaces/i_notifier.rb
+++ b/lib/interfaces/i_notifier.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'interface'
 
 # i_notifier.rb
 # PureMVC Ruby Multicore
@@ -25,7 +26,7 @@ module PureMVC
   #
   # @see IFacade
   # @see INotification
-  module INotifier
+  INotifier = interface {
     # Send a <code>INotification</code>.
     #
     # Convenience method to prevent having to construct new
@@ -51,6 +52,6 @@ module PureMVC
       raise NotImplementedError, "#{self.class} must implement #initialize_notifier"
     end
 
-  end
+  }
 
 end

--- a/lib/interfaces/i_observer.rb
+++ b/lib/interfaces/i_observer.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'interface'
 
 # i_observer.rb
 # PureMVC Ruby Multicore
@@ -37,7 +38,7 @@ module PureMVC
   #
   # @see IView
   # @see INotification
-  module IObserver
+  IObserver = interface {
     # Notify the interested object.
     #
     # @param notification [INotification] the <code>INotification</code> to pass to the interested object's notification method
@@ -53,5 +54,5 @@ module PureMVC
     def compare_notify_context?(object)
       raise NotImplementedError, "#{self.class} must implement #compare_notify_context?"
     end
-  end
+  }
 end

--- a/lib/interfaces/i_proxy.rb
+++ b/lib/interfaces/i_proxy.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'interface'
 
 # i_proxy.rb
 # PureMVC Ruby Multicore
@@ -21,7 +22,7 @@ module PureMVC
   # - Encapsulate interaction with local or remote services used to fetch and persist model data.
   #
   # @see INotifier
-  module IProxy
+  IProxy = interface {
     # @return [String] The proxy name
     def name
       raise NotImplementedError, "#{self.class} must implement #name"
@@ -43,5 +44,5 @@ module PureMVC
     def on_remove
       raise NotImplementedError, "#{self.class} must implement #on_remove"
     end
-  end
+  }
 end

--- a/lib/interfaces/i_view.rb
+++ b/lib/interfaces/i_view.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'interface'
 
 # i_view.rb
 # PureMVC Ruby Multicore
@@ -18,7 +19,7 @@ module PureMVC
   # - Providing a method for attaching <code>IObservers</code> to an <code>INotification</code>'s observer list.
   # - Providing a method for broadcasting an <code>INotification</code>.
   # - Notifying the <code>IObservers</code> of a given <code>INotification</code> when it is broadcast.
-  module IView
+  IView = interface {
     # Register an <code>IObserver</code> to be notified of <code>INotifications</code> with a given name.
     #
     # @param notification_name [String] the name of the <code>INotifications</code> to notify this <code>IObserver</code> of
@@ -90,5 +91,5 @@ module PureMVC
     def remove_mediator(mediator_name)
       raise NotImplementedError, "#{self.class} must implement #remove_mediator"
     end
-  end
+  }
 end

--- a/lib/patterns/command/macro_command.rb
+++ b/lib/patterns/command/macro_command.rb
@@ -6,8 +6,6 @@
 # Copyright(c) 2025 Saad Shams <saad.shams@puremvc.org>
 # Your reuse is governed by the BSD 3-Clause License
 
-require_relative '../../interfaces/i_command'
-
 module PureMVC
   # A base ICommand implementation that executes other ICommand instances.
   #
@@ -23,7 +21,7 @@ module PureMVC
   # @see Notification
   # @see SimpleCommand
   class MacroCommand < Notifier
-    include ICommand
+    implements ICommand
 
     # Constructor.
     #

--- a/lib/patterns/command/simple_command.rb
+++ b/lib/patterns/command/simple_command.rb
@@ -6,8 +6,6 @@
 # Copyright(c) 2025 Saad Shams <saad.shams@puremvc.org>
 # Your reuse is governed by the BSD 3-Clause License
 
-require_relative '../../interfaces/i_command'
-
 module PureMVC
   # A base <code>ICommand</code>implementation.
   #
@@ -18,7 +16,7 @@ module PureMVC
   # @see Notification
   # @see MacroCommand
   class SimpleCommand < Notifier
-    include ICommand
+    implements ICommand
 
     # Fulfill the use-case initiated by the given <code>INotification</code>.
     #

--- a/lib/patterns/facade/facade.rb
+++ b/lib/patterns/facade/facade.rb
@@ -6,8 +6,6 @@
 # Copyright(c) 2025 Saad Shams <saad.shams@puremvc.org>
 # Your reuse is governed by the BSD 3-Clause License
 
-require_relative '../../interfaces/i_facade'
-
 module PureMVC
   # A base Multiton <code>IFacade</code> implementation.
   #
@@ -15,7 +13,7 @@ module PureMVC
   # @see View
   # @see Controller
   class Facade
-    include IFacade, INotifier
+    implements IFacade, INotifier
 
     # Message Constants
     MULTITON_MSG = "Facade instance for this Multiton key already constructed!"

--- a/lib/patterns/mediator/mediator.rb
+++ b/lib/patterns/mediator/mediator.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative '../../interfaces/i_mediator'
-
 # mediator.rb
 # PureMVC Ruby Multicore
 #
@@ -13,7 +11,7 @@ module PureMVC
   #
   # @see View
   class Mediator < Notifier
-    include IMediator
+    implements IMediator
 
     # The name of the <code>Mediator</code>.
     #

--- a/lib/patterns/observer/notification.rb
+++ b/lib/patterns/observer/notification.rb
@@ -6,8 +6,6 @@
 # Copyright(c) 2025 Saad Shams <saad.shams@puremvc.org>
 # Your reuse is governed by the BSD 3-Clause License
 
-require_relative '../../interfaces/i_notification'
-
 module PureMVC
   # A base <code>INotification</code>implementation.
   #
@@ -38,7 +36,7 @@ module PureMVC
   #
   # @see Observer
   class Notification
-    include INotification
+    implements INotification
 
     # @return [String] the name of the notification
     attr_reader :name

--- a/lib/patterns/observer/notifier.rb
+++ b/lib/patterns/observer/notifier.rb
@@ -6,8 +6,6 @@
 # Copyright(c) 2025 Saad Shams <saad.shams@puremvc.org>
 # Your reuse is governed by the BSD 3-Clause License
 
-require_relative '../../interfaces/i_notifier'
-
 module PureMVC
   # A base <code>INotifier</code> implementation.
   #
@@ -40,7 +38,7 @@ module PureMVC
   # @see MacroCommand
   # @see SimpleCommand
   class Notifier
-    include INotifier
+    implements INotifier
 
     # Message Constants
     MULTITON_MSG = "multitonKey for this Notifier not yet initialized!"

--- a/lib/patterns/observer/observer.rb
+++ b/lib/patterns/observer/observer.rb
@@ -6,8 +6,6 @@
 # Copyright(c) 2025 Saad Shams <saad.shams@puremvc.org>
 # Your reuse is governed by the BSD 3-Clause License
 
-require_relative '../../interfaces/i_observer'
-
 module PureMVC
   # A base <code>IObserver</code> implementation.
   #
@@ -24,7 +22,7 @@ module PureMVC
   # @see View
   # @see Notification
   class Observer
-    include IObserver
+    implements IObserver
 
     # @return [Method | nil] notify The callback method to be called on notification.
     attr_accessor :notify

--- a/lib/patterns/proxy/proxy.rb
+++ b/lib/patterns/proxy/proxy.rb
@@ -6,8 +6,6 @@
 # Copyright(c) 2025 Saad Shams <saad.shams@puremvc.org>
 # Your reuse is governed by the BSD 3-Clause License
 
-require_relative '../../interfaces/i_proxy'
-
 module PureMVC
   # A base <code>IProxy</code> implementation.
   #
@@ -23,7 +21,7 @@ module PureMVC
   #
   # @see Model
   class Proxy < Notifier
-    include IProxy
+    implements IProxy
 
     # The name of the <code>Proxy</code>.
     NAME = "Proxy"

--- a/sig/lib/patterns/observer/observer.rbs
+++ b/sig/lib/patterns/observer/observer.rbs
@@ -33,7 +33,6 @@ module PureMVC
     # @param context [Object, nil] the object context for the callback.
     # @return [void]
     def initialize: (Method? notify, Object? context) -> void
-    #def initialize: ((^(_INotification) -> void)?, Object?) -> void
 
     # Calls the notify method with the given notification.
     #


### PR DESCRIPTION
### What?

* Add the `interface` gem as a runtime dependency.
* Update relevant PureMVC modules (e.g., `i_model.rb`, `i_view.rb`, etc.) to use the `interface { … }` DSL instead of plain modules for defining interface contracts.

### Why?

* Enforce Java-style interface semantics at runtime: any class declaring `implements MyInterface` will be validated immediately to ensure required methods exist, catching missing implementations early.
* Provide a clearer, self-documenting contract for PureMVC interfaces so that concrete classes cannot slip through without defining all required methods.
* Maintain consistency with the RBS interface definitions used for static type checking, bridging static and runtime guarantees.

### How?

 - **Require and use in `.rb` files**:

   * At the top of each interface file (e.g. `i_model.rb`), add:

     ```ruby
     # frozen_string_literal: true
     require 'interface'
     ```

- **Update concrete classes**:

   * Any class that previously included `IModel` must now use:

     ```ruby
     class MyModel
       implements IModel
       # …define register_proxy, retrieve_proxy, has_proxy?, remove_proxy
     end
     ```

