### PR TITLE
Assert interface match

### DIFF
--- a/sig/lib/core/controller.rbs
+++ b/sig/lib/core/controller.rbs
@@ -22,6 +22,8 @@ module PureMVC
   # @see MacroCommand
   class Controller
 
+    include _IController
+
     # The Multiton IController instanceMap.
     # @return [Hash{String => _IController}]
     self.@instance_map: Hash[String, _IController]
@@ -130,4 +132,7 @@ module PureMVC
     # @return [void]
     def remove_command: (String notification_name) -> void
   end
+
+  # Type-level assertion that Controller conforms to _IController
+  type controller_validation = validate_controller[Controller]
 end

--- a/sig/lib/core/model.rbs
+++ b/sig/lib/core/model.rbs
@@ -16,6 +16,8 @@ module PureMVC
   # @see IProxy
   class Model
 
+    include _IModel
+
     # The Multiton IModel instanceMap.
     # @return [Hash{String => _IModel}]
     self.@instance_map: Hash[String, _IModel]
@@ -103,4 +105,7 @@ module PureMVC
     # @return [_IProxy, nil] the <code>_IProxy</code> that was removed from the <code>Model</code>, or nil if none found.
     def remove_proxy: (String proxy_name) -> _IProxy?
   end
+
+  # Type-level assertion that Model conforms to _IModel
+  type model_validation = validate_model[Model]
 end

--- a/sig/lib/core/view.rbs
+++ b/sig/lib/core/view.rbs
@@ -16,6 +16,7 @@ module PureMVC
   # @see Notification
   class View
 
+    include _IView
 
     # The Multiton IModel instanceMap.
     # @return [Hash{String => _IView}]
@@ -145,4 +146,7 @@ module PureMVC
     # @return [_IMediator, nil] the <code>_IMediator</code> that was removed from the <code>View</code>, or nil if none found.
     def remove_mediator: (String mediator_name) -> _IMediator?
   end
+
+  # Type-level assertion that View conforms to _IView
+  type view_validation = validate_view[View]
 end

--- a/sig/lib/interfaces/i_command.rbs
+++ b/sig/lib/interfaces/i_command.rbs
@@ -13,4 +13,6 @@ module PureMVC
     # @return [void]
     def execute: (_INotification notification) -> void
   end
+
+  type validate_command[Command < _ICommand] = top
 end

--- a/sig/lib/interfaces/i_controller.rbs
+++ b/sig/lib/interfaces/i_controller.rbs
@@ -49,4 +49,6 @@ module PureMVC
     # @return [void]
     def remove_command: (String notification_name) -> void
   end
+
+  type validate_controller[Controller < _IController] = top
 end

--- a/sig/lib/interfaces/i_facade.rbs
+++ b/sig/lib/interfaces/i_facade.rbs
@@ -99,4 +99,6 @@ module PureMVC
     # @return [void]
     def notify_observers: (_INotification notification) -> void
   end
+
+  type validate_facade[Facade < _IFacade] = top
 end

--- a/sig/lib/interfaces/i_mediator.rbs
+++ b/sig/lib/interfaces/i_mediator.rbs
@@ -30,12 +30,6 @@ module PureMVC
   interface _IMediator
     include _INotifier
 
-    # @return [String] The name of the Mediator.
-    def name: () -> String
-
-    # @return [Object, nil] The view component associated with this Mediator.
-    def view: () -> Object?
-
     # List <code>_INotification</code> interests.
     #
     # @return [Array] an <code>Array</code> of the <code>_INotification</code> names this <code>_IMediator</code> has an interest in.
@@ -55,4 +49,6 @@ module PureMVC
     # @return [void]
     def on_remove: () -> void
   end
+
+  type validate_mediator[Mediator < _IMediator] = top
 end

--- a/sig/lib/interfaces/i_model.rbs
+++ b/sig/lib/interfaces/i_model.rbs
@@ -33,4 +33,6 @@ module PureMVC
     # @return [_IProxy | nil] the <code>_IProxy</code> that was removed from the <code>Model</code>.
     def remove_proxy: (String proxy_name) -> _IProxy?
   end
+
+  type validate_model[Model < _IModel] = top
 end

--- a/sig/lib/interfaces/i_notification.rbs
+++ b/sig/lib/interfaces/i_notification.rbs
@@ -30,18 +30,11 @@ module PureMVC
   # @see IView
   # @see IObserver
   interface _INotification
-    # @return [String] the name of the notification
-    def name: () -> String
-
-    # @return [Object, nil] the body of the notification
-    def body: () -> Object?
-
-    # @return [String, nil] the type of the notification
-    def type: () -> String?
-
     # Get the string representation of the <code>_INotification</code> instance
     #
     # @return [String]
     def to_s: () -> String
   end
+
+  type validate_notification[Notification < _INotification] = top
 end

--- a/sig/lib/interfaces/i_notifier.rbs
+++ b/sig/lib/interfaces/i_notifier.rbs
@@ -39,4 +39,6 @@ module PureMVC
     # @return [void]
     def initialize_notifier: (String key) -> void
   end
+
+  type validate_notifier[Notifier < _INotifier] = top
 end

--- a/sig/lib/interfaces/i_observer.rbs
+++ b/sig/lib/interfaces/i_observer.rbs
@@ -42,4 +42,6 @@ module PureMVC
     # @return [Boolean] indicating if the notification context and the object are the same.
     def compare_notify_context?: (Object object) -> bool
   end
+
+  type validate_observer[Observer < _IObserver] = top
 end

--- a/sig/lib/interfaces/i_proxy.rbs
+++ b/sig/lib/interfaces/i_proxy.rbs
@@ -17,12 +17,6 @@ module PureMVC
 
     include _INotifier
 
-    # @return [String] The proxy name
-    def name: () -> String
-
-    # @return [Object | nil] The data managed by the proxy
-    def data: () -> Object?
-
     # Called by the Model when the Proxy is registered
     # @return [void]
     def on_register: () -> void
@@ -31,4 +25,6 @@ module PureMVC
     # @return [void]
     def on_remove: () -> void
   end
+
+  type validate_proxy[Proxy < _IProxy] = top
 end

--- a/sig/lib/interfaces/i_view.rbs
+++ b/sig/lib/interfaces/i_view.rbs
@@ -69,4 +69,6 @@ module PureMVC
     # @return [_IMediator] the <code>_IMediator</code> that was removed from the <code>View</code>
     def remove_mediator: (String mediator_name) -> _IMediator?
   end
+
+  type validate_view[View < _IView] = top
 end

--- a/sig/lib/patterns/command/macro_command.rbs
+++ b/sig/lib/patterns/command/macro_command.rbs
@@ -61,4 +61,7 @@ module PureMVC
     # @return [void]
     def execute: (_INotification notification) -> void
   end
+
+  # Type-level assertion that MacroCommand conforms to _ICommand
+  type macro_command_validation = validate_command[MacroCommand]
 end

--- a/sig/lib/patterns/command/simple_command.rbs
+++ b/sig/lib/patterns/command/simple_command.rbs
@@ -21,4 +21,7 @@ module PureMVC
     # @return [void]
     def execute: (_INotification notification) -> void
   end
+
+  # Type-level assertion that SimpleCommand conforms to _ICommand
+  type simple_command_validation = validate_command[SimpleCommand]
 end

--- a/sig/lib/patterns/facade/facade.rbs
+++ b/sig/lib/patterns/facade/facade.rbs
@@ -229,4 +229,7 @@ module PureMVC
     # @return [void]
     def initialize_notifier: (String key) -> void
   end
+
+  # Type-level assertion that Facade conforms to _IFacade
+  type facade_validation = validate_facade[Facade]
 end

--- a/sig/lib/patterns/mediator/mediator.rbs
+++ b/sig/lib/patterns/mediator/mediator.rbs
@@ -47,4 +47,7 @@ module PureMVC
     # @return [void]
     def on_remove: () -> void
   end
+
+  # Type-level assertion that Mediator conforms to _IMediator
+  type mediator_validation = validate_mediator[Mediator]
 end

--- a/sig/lib/patterns/observer/notification.rbs
+++ b/sig/lib/patterns/observer/notification.rbs
@@ -59,4 +59,7 @@ module PureMVC
     # @return [String]
     def to_s: () -> ::String
   end
+
+  # Type-level assertion that Notification conforms to _INotification
+  type notification_validation = validate_notification[Notification]
 end

--- a/sig/lib/patterns/observer/notifier.rbs
+++ b/sig/lib/patterns/observer/notifier.rbs
@@ -74,4 +74,7 @@ module PureMVC
     # @return [_IFacade] the facade instance for the notifier's key
     def facade: () -> _IFacade
   end
+
+  # Type-level assertion that Notifier conforms to _INotifier
+  type notifier_validation = validate_notifier[Notifier]
 end

--- a/sig/lib/patterns/observer/observer.rbs
+++ b/sig/lib/patterns/observer/observer.rbs
@@ -46,4 +46,7 @@ module PureMVC
     # @return [Boolean] true if the given object is the same as the context.
     def compare_notify_context?: (Object) -> bool
   end
+
+  # Type-level assertion that Observer conforms to _IObserver
+  type observer_validation = validate_observer[Observer]
 end

--- a/sig/lib/patterns/proxy/proxy.rbs
+++ b/sig/lib/patterns/proxy/proxy.rbs
@@ -41,4 +41,7 @@ module PureMVC
     # @return [void]
     def on_remove: () -> void
   end
+
+  # Type-level assertion that Proxy conforms to _IProxy
+  type proxy_validation = validate_proxy[Proxy]
 end


### PR DESCRIPTION
### What?

* Added type-level assertions to validate that classes  conform to interfaces.
* Removed `attr_reader`-backed method declarations (`name`, `body`, and `type`) from  interfaces to avoid false positives in type checking, since meta-programming methods aren't enforced by Steep.

---

### Why?

* Type assertions using `validate_command[...]` ensure that our command classes actually implement all required interface methods at compile time, improving type safety.
* Steep does not type-check methods defined via meta-programming (e.g., `attr_reader`), so including them in interfaces leads to unnecessary type errors. Removing these methods from the RBS interfaces avoids this issue and aligns interface expectations with actual enforceable method implementations.

---

### How?

* Introduced type-level assertions:

  ```ruby
  type validate_command[Command < _ICommand] = top
  type macro_command_validation = validate_command[MacroCommand]
  type simple_command_validation = validate_command[SimpleCommand]
  ```

* Removed attribute reader methods from interfaces:
