### PR TITLE
Local var types

### DIFF
--- a/lib/core/controller.rb
+++ b/lib/core/controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: true
 
 # controller.rb
 # PureMVC Ruby Multicore
@@ -164,7 +165,7 @@ module PureMVC
     # @return [void]
     def remove_command(notification_name)
       @command_mutex.synchronize do
-        # @type command [ICommand]
+        # @type command [(() -> ICommand)?]
         command = @command_map[notification_name]
 
         # if the Command is registered...

--- a/lib/core/model.rb
+++ b/lib/core/model.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: true
 
 # model.rb
 # PureMVC Ruby Multicore
@@ -129,6 +130,7 @@ module PureMVC
     # @param proxy_name [String] name of the <code>IProxy</code> instance to be removed.
     # @return [IProxy, nil] the <code>IProxy</code> that was removed from the <code>Model</code>, or nil if none found.
     def remove_proxy(proxy_name)
+      # @type proxy [_IProxy?]
       proxy = nil
       @proxy_mutex.synchronize do
         proxy = @proxy_map.delete(proxy_name)

--- a/lib/core/view.rb
+++ b/lib/core/view.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: true
 
 # view.rb
 # PureMVC Ruby Multicore
@@ -121,6 +122,7 @@ module PureMVC
     # @param notification [INotification] the <code>INotification</code> to notify <code>IObservers</code> of.
     # @return [void]
     def notify_observers(notification)
+      # @type observers [Array<IObserver>?]
       observers = nil
       @observer_mutex.synchronize do
         # Get a reference to the observers list for this notification name
@@ -141,6 +143,7 @@ module PureMVC
     def remove_observer(notification_name, notify_context)
       @observer_mutex.synchronize do
         # the observer list for the notification under inspection
+        # @type observers [Array<IObserver>?]
         observers = @observer_map[notification_name]
         # find and remove the sole Observer for the given notify_context
         # there can only be one Observer for a given notify_context
@@ -167,6 +170,7 @@ module PureMVC
     # @param mediator [IMediator] a reference to the <code>IMediator</code> instance
     # @return [void]
     def register_mediator(mediator)
+      # @type exists [Boolean]
       exists = false
       @mediator_mutex.synchronize do
         # do not allow re-registration (you must to removeMediator first)
@@ -182,9 +186,11 @@ module PureMVC
       mediator.initialize_notifier(@multiton_key)
 
       # Create Observer referencing this mediator's handleNotification method
+      # @type observer [Observer]
       observer = Observer.new(mediator.method(:handle_notification), mediator)
 
       # Get Notification interests, if any.
+      # @type interests [Array<String>]
       interests = mediator.list_notification_interests
       # Register Mediator as Observer for its list of Notification interests
       interests.each { |interest| register_observer(interest, observer) }
@@ -218,6 +224,7 @@ module PureMVC
     # @param mediator_name [String] name of the <code>IMediator</code> instance to be removed.
     # @return [IMediator, nil] the <code>IMediator</code> that was removed from the <code>View</code>, or nil if none found.
     def remove_mediator(mediator_name)
+      # @type mediator [IMediator?]
       mediator = nil
       @mediator_mutex.synchronize do
         # retrieve the named mediator and delete from the mediator map
@@ -227,6 +234,7 @@ module PureMVC
       return unless mediator
 
       # for every notification this mediator is interested in...
+      # @type interests [Array<String>]
       interests = mediator.list_notification_interests
       # remove the observer linking the mediator
       # to the notification interest

--- a/lib/patterns/command/macro_command.rb
+++ b/lib/patterns/command/macro_command.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: true
 
 # macro_command.rb
 # PureMVC Ruby Multicore
@@ -74,7 +75,10 @@ module PureMVC
     # @return [void]
     def execute(notification)
       while @sub_commands.any?
+        # @type factory [() -> ICommand]
         factory = @sub_commands.shift
+
+        # @type command [ICommand]
         command = factory.call
         command.initialize_notifier(@multiton_key)
         command.execute(notification)

--- a/sig/lib/interfaces/i_command.rbs
+++ b/sig/lib/interfaces/i_command.rbs
@@ -14,5 +14,6 @@ module PureMVC
     def execute: (_INotification notification) -> void
   end
 
+  # Assert that the given `Command` type parameter is a subtype of `_ICommand`
   type validate_command[Command < _ICommand] = top
 end

--- a/sig/lib/interfaces/i_controller.rbs
+++ b/sig/lib/interfaces/i_controller.rbs
@@ -50,5 +50,6 @@ module PureMVC
     def remove_command: (String notification_name) -> void
   end
 
+  # Assert that the given `Controller` type parameter is a subtype of `_IController`
   type validate_controller[Controller < _IController] = top
 end

--- a/sig/lib/interfaces/i_facade.rbs
+++ b/sig/lib/interfaces/i_facade.rbs
@@ -100,5 +100,6 @@ module PureMVC
     def notify_observers: (_INotification notification) -> void
   end
 
+  # Assert that the given `Facade` type parameter is a subtype of `_IFacade`
   type validate_facade[Facade < _IFacade] = top
 end

--- a/sig/lib/interfaces/i_mediator.rbs
+++ b/sig/lib/interfaces/i_mediator.rbs
@@ -56,5 +56,6 @@ module PureMVC
     def on_remove: () -> void
   end
 
+  # Assert that the given `Mediator` type parameter is a subtype of `_IMediator`
   type validate_mediator[Mediator < _IMediator] = top
 end

--- a/sig/lib/interfaces/i_model.rbs
+++ b/sig/lib/interfaces/i_model.rbs
@@ -34,5 +34,6 @@ module PureMVC
     def remove_proxy: (String proxy_name) -> _IProxy?
   end
 
+  # Assert that the given `Model` type parameter is a subtype of `_IModel`
   type validate_model[Model < _IModel] = top
 end

--- a/sig/lib/interfaces/i_notification.rbs
+++ b/sig/lib/interfaces/i_notification.rbs
@@ -45,5 +45,6 @@ module PureMVC
     def to_s: () -> String
   end
 
+  # Assert that the given `Notification` type parameter is a subtype of `_INotification`
   type validate_notification[Notification < _INotification] = top
 end

--- a/sig/lib/interfaces/i_notifier.rbs
+++ b/sig/lib/interfaces/i_notifier.rbs
@@ -40,5 +40,6 @@ module PureMVC
     def initialize_notifier: (String key) -> void
   end
 
+  # Assert that the given `Notifier` type parameter is a subtype of `_INotifier`
   type validate_notifier[Notifier < _INotifier] = top
 end

--- a/sig/lib/interfaces/i_observer.rbs
+++ b/sig/lib/interfaces/i_observer.rbs
@@ -43,5 +43,6 @@ module PureMVC
     def compare_notify_context?: (Object object) -> bool
   end
 
+  # Assert that the given `Observer` type parameter is a subtype of `_IObserver`
   type validate_observer[Observer < _IObserver] = top
 end

--- a/sig/lib/interfaces/i_proxy.rbs
+++ b/sig/lib/interfaces/i_proxy.rbs
@@ -32,5 +32,6 @@ module PureMVC
     def on_remove: () -> void
   end
 
+  # Assert that the given `Proxy` type parameter is a subtype of `_IProxy`
   type validate_proxy[Proxy < _IProxy] = top
 end

--- a/sig/lib/interfaces/i_view.rbs
+++ b/sig/lib/interfaces/i_view.rbs
@@ -70,5 +70,6 @@ module PureMVC
     def remove_mediator: (String mediator_name) -> _IMediator?
   end
 
+  # Assert that the given `View` type parameter is a subtype of `_IView`
   type validate_view[View < _IView] = top
 end


### PR DESCRIPTION
### What?

Added local‐variable type annotations and file‐level strictness pragmas (`# typed: true`) across several PureMVC core files (e.g., Controller, Model, View, MacroCommand). Each local assignment that could introduce a nullable or complex type now has a `# @type` comment to explicitly declare its expected type.

### Why?

To enable Steep static type checking on local variables. Ensuring that procs, returned values, and optional objects are correctly typed. This prevents mismatches (e.g., calling `.call` on something that might be nil) and increases code safety by catching type errors at “compile” time rather than at runtime.

### How?

* Added `# typed: true` to the top of each Ruby file to opt into true type checking.
* Inserted `# @type` annotations immediately above each local‐variable assignment
